### PR TITLE
Add option to force cuda compilation via env flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,20 @@ from distutils.command.clean import clean
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 from torch.cuda import is_available as torch_cuda_available
 from rational import __version__
+import os
 degrees = [(3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (5, 4), (7, 6)]
 # degrees = [(5, 4), (7, 6)]
 
+def is_torch_cuda_available():
+    """Wrapper for torch cuda availability check (torch.cuda.is_available) that takes an environment variable
+    'FORCE_CUDA' into account and returns also true iff FORCE_CUDA=1.
+
+    This is necessary when building rational in a Dockerfile script since the docker build pass doesn't have
+    access to cuda and thus torch.cuda.is_available always returns false, even when the docker image which is
+    to be built in fact does have cuda.
+    """
+    force_cuda = os.getenv("FORCE_CUDA", "0") == "1"
+    return force_cuda or torch_cuda_available()
 
 def generate_cpp_module(fname, degrees=degrees, versions=None):
     file_content = airspeed.Template("""
@@ -100,7 +111,7 @@ constexpr uint32_t THREADS_PER_BLOCK = 512;
     with open(fname, "w") as text_file:
         text_file.write(content)
 
-if torch_cuda_available():
+if is_torch_cuda_available():
     version_names = []
     template_contents = ""
     for template_fname in sorted(glob.glob("rational/_cuda/versions/*.cu")):
@@ -161,7 +172,7 @@ setup(
             'nvcc': ['-gencode=arch=compute_60,code="sm_60,compute_60"', '-lineinfo']
         }
     ),
-    ] if torch_cuda_available() else [],
+    ] if is_torch_cuda_available() else [],
     cmdclass={
         'build_ext': BuildExtension,
         'clean': clean_all


### PR DESCRIPTION
Add a wrapper for torch cuda availability check (torch.cuda.is_available) that takes an environment variable 'FORCE_CUDA' into account and returns also true iff FORCE_CUDA=1.

This is necessary when building rational in a Dockerfile script since the docker build pass doesn't have access to cuda and thus torch.cuda.is_available always returns false, even when the docker image which is to be built in fact does have cuda.